### PR TITLE
Restrict cakephp version to greater than 2.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require": {
 		"php": ">=5.2.17",
-		"cakephp/cakephp": ">=2.4 <3.0",
+		"cakephp/cakephp": ">=2.9.0 <3.0",
 		"composer/installers": "*"
 	}
 }


### PR DESCRIPTION
The recent version switched the Object reference
to CakeObject. This class wasn't added until 2.9
so updating the composer requirements to need
that version of cake.